### PR TITLE
1 fix refresh token exposure issue

### DIFF
--- a/src/main/java/com/personal_baseball/domain/RefreshToken.java
+++ b/src/main/java/com/personal_baseball/domain/RefreshToken.java
@@ -19,11 +19,11 @@ public class RefreshToken {
     @Column(name = "refresh_id")
     private Long refreshId;
 
-    @Column(name = "user_id", insertable = false, updatable = false)
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id",insertable = false, updatable = false)
     private User user;
 
     @Column(name = "token", nullable = false, unique = true, length = 500)

--- a/src/main/java/com/personal_baseball/security/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/personal_baseball/security/OAuthLoginSuccessHandler.java
@@ -106,7 +106,7 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
 
         //프론트엔드로 리다이렉트
         String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
-        String redirectUri = String.format(REDIRECT_URI, encodedName,accessToken, refreshToken);
+        String redirectUri = String.format(REDIRECT_URI, encodedName,accessToken);
 
         log.info("리다이렉트 URI : {}", redirectUri);
         getRedirectStrategy().sendRedirect(request,response,redirectUri);


### PR DESCRIPTION
## 📌 PR 목적 및 개요

-  #1 
- [문제 수정]

## 📝 작업 내용

- 작업한 내용을 간략히 작성해주세요.
  - Refresh Token을 cilent에게 보내지 않도록 수정
  - Token 전달 방식을 기존 Response Body에서 Authorization Header로 변경
  - 기존 RefreshToken으로 Access Token을 재발급 받는 로직에서 (만료된) Access Token을 이용해 재발급 받을 수 있도록 수정

## ✅ 확인 및 점검 사항

- [x] 변경 사항이 제대로 동작하는지 로컬에서 테스트했습니다.

## 🔗 참고 링크 및 자료 (선택사항)

- 참고할만한 링크나 문서가 있다면 추가해주세요.
